### PR TITLE
feature/CN-2760-add-no-https-redirect

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -20,6 +20,7 @@ const (
 	IssueEventWebshell              = "webshell"
 	IssueEventBaselineEmpty         = "baseline-empty"
 	IssueEventContentViolation      = "content-violation"
+	IssueEventNoHTTPSRedirect       = "no-https-redirect"
 )
 
 const (

--- a/types.go
+++ b/types.go
@@ -482,6 +482,10 @@ func UnmarshalDetails(event string, details []byte) (interface{}, error) {
 			return nil, err
 		}
 		return specificDetails, nil
+	case IssueEventNoHTTPSRedirect:
+		// currently no specific details are stored for "no-https-redirect"
+		fmt.Printf("event: %s does not store specific details", event)
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("event '%s' unknown | %s", event, string(details))
 	}

--- a/types.go
+++ b/types.go
@@ -483,8 +483,7 @@ func UnmarshalDetails(event string, details []byte) (interface{}, error) {
 		}
 		return specificDetails, nil
 	case IssueEventNoHTTPSRedirect:
-		// currently no specific details are stored for "no-https-redirect"
-		fmt.Printf("event: %s does not store specific details", event)
+		// currently, no specific details are held by "no-https-redirect" issues
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("event '%s' unknown | %s", event, string(details))


### PR DESCRIPTION
As the api already returns issues where event='no-https-redirect' we now include it in the sdk

UnmarshalDetails was adjusted, however currently the details of no-https-redirect issues are always empty.
No logging or error return was added for this case, to avoid console spam and interruptions when unmarshalling inside of a loop.